### PR TITLE
Use spread on props

### DIFF
--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -36,5 +36,11 @@ module.exports = React.createClass
     src = base + md5.digest_s(@props.email) + "?" + query
 
     return(
-      <img className={"react-gravatar " + @props.className} src={src} alt={@props.email} height={@props.size} width={@props.size} />
+      <img
+        {... @props}
+        className={"react-gravatar " + @props.className}
+        src={src}
+        alt={@props.email}
+        height={@props.size}
+        width={@props.size} />
     )


### PR DESCRIPTION
If we apply the jsx spread attribute to combine props we can use style, onClick etc. without modifying the react-gravatar component.
