### PR TITLE
srcset-based retina support

### DIFF
--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -29,7 +29,13 @@ module.exports = React.createClass
       'http://www.gravatar.com/avatar/'
 
     query = querystring.stringify({
-      s: if isRetina() then @props.size * 2 else @props.size
+      s: @props.size
+      r: @props.rating
+      d: @props.default
+    })
+
+    retinaQuery = querystring.stringify({
+      s: @props.size * 2
       r: @props.rating
       d: @props.default
     })
@@ -43,12 +49,30 @@ module.exports = React.createClass
       return(<script/>)
 
     src = base + hash + "?" + query
+    retinaSrc = base + hash + "?" + retinaQuery
+
+    modernBrowser = true  # server-side, we render for modern browsers
+
+    if window?
+      # this is not NodeJS
+      modernBrowser = 'srcset' in createElement('img')
+
+    if !modernBrowser and isRetina()
+      return(
+        <img
+          {...@props}
+          className={"react-gravatar " + @props.className}
+          src={retinaSrc}
+          height={@props.size}
+          width={@props.size} />
+      )
 
     return(
       <img
         {...@props}
         className={"react-gravatar " + @props.className}
         src={src}
+        srcset={retinaSrc + " 2x"}
         height={@props.size}
         width={@props.size} />
     )


### PR DESCRIPTION
Current approach to retina support is breaking isomorphic rendering: server builds html for non-retina displays and client overrides it with other path to images.

Would you take patch for html5-based support (`srcset` attribute) instead?

Browser support: http://caniuse.com/#feat=srcset
