### PR TITLE
fix "of" vs "in" syntax error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ release-major:
 
 build:
 	@$(BIN)/cjsx -cb -o dist src/index.cjsx
-	@$(BIN)/browserify examples/index.js -o examples/bundle.js
+	@$(BIN)/browserify -t babelify examples/index.js -o examples/bundle.js
 
 publish:
 	git push --tags origin HEAD:master

--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -55,7 +55,7 @@ module.exports = React.createClass
 
     if window?
       # this is not NodeJS
-      modernBrowser = 'srcset' in document.createElement('img')
+      modernBrowser = 'srcset' of document.createElement('img')
 
     if not modernBrowser and isRetina()
       <img


### PR DESCRIPTION
Found a syntax error that was causing react to render differently on the server-side vs the client-side. On line 58 "in" should be "of":

> ```
>   modernBrowser = 'srcset' in document.createElement('img')
> ```

That compiles to `modernBrowser = indexOf.call(document.createElement('img'), 'srcset') >= 0`, or in other words, treat this image element as if it were an array and see if the array contains the string 'srcset'. Clearly this was not what was intended.

In this pull request, I change it to use the 'of' keyword, which gets compiles to `modernBrowser = 'srcset' in document.createElement('img')`.

Also, the makefile didn't have the babelify transform for the build task. Without it, the task would fail with syntax errors. I added that, and now the build task works.
