### PR TITLE
Move babelify to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/KyleAMathews/react-gravatar/issues"
   },
   "dependencies": {
-    "babelify": "^6.4.0",
     "is-retina": "^1.0.3",
     "md5": "^2.0.0",
     "react-dom": "^0.14.0"
   },
   "devDependencies": {
+    "babelify": "^6.4.0",
     "browserify": "^11.2.0",
     "coffee-react": "^4.0.0",
     "react": "^0.14.0"


### PR DESCRIPTION
Thanks for awesome component, we are using it in our project.
There is a tiny thing - babelify gets installed every CI build, which is unnecessary action and takes significant time for us.
