### PR TITLE
Add protocol prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,16 +12,18 @@ class Gravatar extends React.Component {
     rating: React.PropTypes.string,
     default: React.PropTypes.string,
     className: React.PropTypes.string,
+    protocol: React.PropTypes.string,
     style: React.PropTypes.object,
   }
   static defaultProps = {
     size: 50,
     rating: 'g',
     default: 'retro',
+    protocol: '//',
   }
 
   render() {
-    const base = '//www.gravatar.com/avatar/'
+    const base = `${this.props.protocol}www.gravatar.com/avatar/`
 
     const query = querystring.stringify({
       s: this.props.size,

--- a/www/pages/index.js
+++ b/www/pages/index.js
@@ -89,6 +89,7 @@ const IndexRoute = React.createClass({
             <li><code>default: React.PropTypes.string</code> — Pick the type of fallback image to use. Defaults to 'retro'</li>
             <li><code>className: React.PropTypes.string</code> — Add a className to the generated image.</li>
             <li><code>style: React.PropTypes.object</code> — Set styles on the image.</li>
+            <li><code>protocol: React.PropTypes.string</code> — Use different protocol (http://, https://, etc.) Defaults to '//'</li>
           </ul>
         </div>
       </Container>


### PR DESCRIPTION
User can specify protocol like `https://`, `http://`. This is because of Electron that uses `file://` protocol for example therefore wouldn't show the Gravatar.

It broke our app, because of this PR: https://github.com/KyleAMathews/react-gravatar/pull/105.
