### PR TITLE
Fix missing prop-types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "is-retina": "^1.0.3",
     "md5": "^2.1.0",
+    "prop-types": "^15.5.10",
     "query-string": "^4.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The `prop-types` module was missing in `package.json`. It threw an error when ever you tried to require `react-gravatar`.