### PR TITLE
Only show email in alt attr if it was supplied

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class Gravatar extends React.Component {
     if (!modernBrowser && isRetina()) {
       return (
         <img
-          alt={`Gravatar for ${formattedEmail}`}
+          alt={this.props.email ? `Gravatar for ${formattedEmail}` : `Gravatar`}
           style={this.props.style}
           src={retinaSrc}
           height={this.props.size}


### PR DESCRIPTION
Prevents alt tag from reading "Gravatar for undefined" if MD5 prop was supplied instead of email.

Also fixes https://github.com/KyleAMathews/react-gravatar/issues/144