### PR TITLE
Support for configurable domain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ class Gravatar extends React.Component {
     default: PropTypes.string,
     className: PropTypes.string,
     protocol: PropTypes.string,
+    domain: PropTypes.string,
     style: PropTypes.object,
   }
   static defaultProps = {
@@ -21,10 +22,11 @@ class Gravatar extends React.Component {
     rating: 'g',
     default: 'retro',
     protocol: '//',
+    domain: 'www.gravatar.com',
   }
 
   render() {
-    const base = `${this.props.protocol}www.gravatar.com/avatar/`
+    const base = `${this.props.protocol}${this.props.domain}/avatar/`
 
     const query = querystring.stringify({
       s: this.props.size,


### PR DESCRIPTION
I often see issues of 503s when accessing gravatar thumbnails.

I asked their technical support, and this is what they replied:

```
[...] thanks for reaching out to us about the 503 errors you're seeing.

I've checked in with our Systems team on this, and they've let me know that the 503 rate is between 0.01% and 0.02%.

As a workaround for this, consider switching the hostname to en.gravatar.com and it will stop the 503s.
[...]
```

I checked, and, indeed, urls that give me 503s work fine if I use `en.gravatar.com` as the domain.

Hence the current PR. :-)